### PR TITLE
fix: drop cloudflare/ai dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1862,11 +1862,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@cloudflare/ai": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/ai/-/ai-1.1.0.tgz",
-			"integrity": "sha512-6j2aeelMfPj2YVj/zQBAj9PAbEZSrO/t+Wywy3Gvk93JsTlsZvEH+V9JYIZHynhSt0juuOrSWP9ju3vN6lUDMQ=="
-		},
 		"node_modules/@cloudflare/workers-types": {
 			"version": "4.20240502.0",
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240502.0.tgz",
@@ -11502,9 +11497,6 @@
 			"name": "@codebam/cf-workers-telegram-bot",
 			"version": "5.18.0",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@cloudflare/ai": "1.1.0"
-			},
 			"devDependencies": {
 				"@cloudflare/workers-types": "^4.20240502.0",
 				"@eslint/js": "^9.2.0",
@@ -11704,9 +11696,6 @@
 		"packages/worker": {
 			"version": "5.17.0",
 			"license": "Apache-2.0",
-			"dependencies": {
-				"@cloudflare/ai": "1.0.53"
-			},
 			"devDependencies": {
 				"@babel/preset-env": "^7.24.5",
 				"@cloudflare/workers-types": "^4.20240502.0",
@@ -11724,11 +11713,6 @@
 				"typescript": "^5.4.5",
 				"typescript-eslint": "^7.8.0"
 			}
-		},
-		"packages/worker/node_modules/@cloudflare/ai": {
-			"version": "1.0.53",
-			"resolved": "https://registry.npmjs.org/@cloudflare/ai/-/ai-1.0.53.tgz",
-			"integrity": "sha512-bVuvvm+LU/EoZ5mehL0uakOld1gvrOEQpnRqXbkNIjypHlxTLPLe3LDU3RZdaSTTUI+dK5beLI5qcmAu8h1/iQ=="
 		},
 		"packages/worker/node_modules/@eslint/eslintrc": {
 			"version": "3.0.2",

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -40,8 +40,5 @@
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.8.0"
-  },
-  "dependencies": {
-    "@cloudflare/ai": "1.1.0"
   }
 }

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -28,8 +28,5 @@
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",
     "typescript-eslint": "^7.8.0"
-  },
-  "dependencies": {
-    "@cloudflare/ai": "1.0.53"
   }
 }


### PR DESCRIPTION
As of https://github.com/codebam/cf-workers-telegram-bot/commit/e29d63640ec1d81397ae7d89747e84331bdcee2a, this package is using the native Workers AI binding and no longer needs to depend on `@cloudflare/ai`.